### PR TITLE
feat: configure which files to stage

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,8 @@ func init() {
 
 	// git-related flags
 	pflag.StringVar(&options.UpdateOptions.Git.CloneDir, "git-clone-dir", temporaryDirectory(), "")
+	pflag.StringArrayVar(&options.UpdateOptions.Git.StagePatterns, "git-stage-pattern", nil, "")
+	pflag.BoolVar(&options.UpdateOptions.Git.StageAllChanged, "git-stage-all-changed", true, "")
 	pflag.StringVar(&options.UpdateOptions.Git.AuthorName, "git-author-name", firstNonEmpyValue(os.Getenv("GIT_AUTHOR_NAME"), git.ConfigValue("user.name")), "")
 	pflag.StringVar(&options.UpdateOptions.Git.AuthorEmail, "git-author-email", firstNonEmpyValue(os.Getenv("GIT_AUTHOR_EMAIL"), git.ConfigValue("user.email")), "")
 	pflag.StringVar(&options.UpdateOptions.Git.CommitterName, "git-committer-name", firstNonEmpyValue(os.Getenv("GIT_COMMITTER_NAME"), git.ConfigValue("user.name")), "")

--- a/repository/git.go
+++ b/repository/git.go
@@ -107,6 +107,13 @@ func commitChanges(ctx context.Context, gitRepo *git.Repository, options UpdateO
 		"status":          status.String(),
 	}).Debug("Git status")
 
+	for _, pattern := range options.Git.StagePatterns {
+		err = workTree.AddGlob(pattern)
+		if err != nil {
+			return false, fmt.Errorf("failed to stage files using pattern %s: %w", pattern, err)
+		}
+	}
+
 	now := time.Now()
 	commitMsg := new(strings.Builder)
 	commitMsg.WriteString(options.Git.CommitTitle)
@@ -121,7 +128,7 @@ func commitChanges(ctx context.Context, gitRepo *git.Repository, options UpdateO
 
 	commit, err := workTree.Commit(commitMsg.String(),
 		&git.CommitOptions{
-			All: true,
+			All: options.Git.StageAllChanged,
 			Author: &object.Signature{
 				Name:  options.Git.AuthorName,
 				Email: options.Git.AuthorEmail,

--- a/repository/options.go
+++ b/repository/options.go
@@ -24,15 +24,17 @@ type UpdateOptions struct {
 }
 
 type GitOptions struct {
-	CloneDir       string
-	AuthorName     string
-	AuthorEmail    string
-	CommitterName  string
-	CommitterEmail string
-	CommitTitle    string
-	CommitBody     string
-	CommitFooter   string
-	BranchPrefix   string
+	CloneDir        string
+	StagePatterns   []string
+	StageAllChanged bool
+	AuthorName      string
+	AuthorEmail     string
+	CommitterName   string
+	CommitterEmail  string
+	CommitTitle     string
+	CommitBody      string
+	CommitFooter    string
+	BranchPrefix    string
 }
 
 type GitHubOptions struct {


### PR DESCRIPTION
- `--git-stage-all-changed`, default to `true` to keep the existing behaviour
  note that this only takes "changed" files in account: modified files or deleted files. not new files.
- `--git-stage-pattern`: one or more patterns to add glob of files to the index